### PR TITLE
bugfix - missing font causing crash

### DIFF
--- a/app/src/main/java/com/kanshu/kanshu/BaseActivity.java
+++ b/app/src/main/java/com/kanshu/kanshu/BaseActivity.java
@@ -14,7 +14,7 @@ public class BaseActivity extends ActionBarActivity {
     public void onCreate(Bundle savedInstanceState, PersistableBundle persistentState) {
         super.onCreate(savedInstanceState, persistentState);
         CalligraphyConfig.initDefault(new CalligraphyConfig.Builder()
-                .setDefaultFontPath("fonts/Roboto-Roboto.ttf")
+                .setDefaultFontPath("fonts/Roboto-Regular.ttf")
                 .setFontAttrId(R.attr.fontPath)
                 .build()
         );


### PR DESCRIPTION
Calligraphy﹕ Can't create asset from fonts/Roboto-Roboto.ttf. Make sure you have passed in the correct path and file name.
    java.lang.RuntimeException: Font asset not found fonts/Roboto-Roboto.ttf